### PR TITLE
General fixups for Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,13 @@ compiler:
   - clang
   - gcc
 
+addons:
+  apt:
+    sources:
+      - sourceline: 'deb http://en.archive.ubuntu.com/ubuntu/ artful main universe'
+    packages:
+      - e2fsprogs
+
 install:
   - sudo make travis-install
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,6 @@
 language: c
 sudo: required
 dist: trusty
-compiler:
-  - clang
-  - gcc
 
 addons:
   apt:
@@ -13,8 +10,6 @@ addons:
       - e2fsprogs
       - python-pytest
       - python-keyutils
-      - clang
-      - clang-format
 
 install:
   - sudo make travis-install

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,12 @@
+language: c
+sudo: required
+dist: trusty
+compiler:
+  - clang
+  - gcc
+
+install:
+  - sudo make travis-install
+
+script:
+  - sudo make travis-script

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,10 @@ addons:
       - sourceline: 'deb http://en.archive.ubuntu.com/ubuntu/ artful main universe'
     packages:
       - e2fsprogs
+      - python-pytest
+      - python-keyutils
+      - clang
+      - clang-format
 
 install:
   - sudo make travis-install

--- a/Makefile
+++ b/Makefile
@@ -15,34 +15,113 @@
 # License for the specific language governing permissions and limitations under
 # the License.
 
+# Update on each new release!!
+RELEASE_VERSION = 0.1.0
+
 NAME = fscryptctl
-CFLAGS += -O2 -Wall
 
-INSTALL = install
-DESTDIR = /usr/local/bin
+INSTALL ?= install
+DESTDIR ?= /usr/local/bin
 
-OBJECTS = $(NAME).o sha512.o
+C_FILES = $(shell find . -type f -name "*.h" -o -name "*.c")
 
-.PHONY: default all clean format $(NAME)
+# IMAGE will be the path to our test ext4 image file.
+IMAGE ?= $(NAME)_image
 
+# MOUNT will be the path to the filesystem where our tests are run.
+#
+# Running "make test-setup MOUNT=/foo/bar" creates a test filesystem at that
+#	location. Be sure to also run "make test-teardown MOUNT=/foo/bar".
+# Running "make all MOUNT=/foo/bar" (or "make go") will run all tests on that
+# 	filesystem. By default, it is the one created with "make test-setup".
+MOUNT ?= /mnt/$(NAME)_mount
+export TEST_FILESYSTEM_ROOT = $(MOUNT)
+
+# The flags code below lets the caller of the makefile change the build flags
+# for fscryptctl in a familiar manner.
+#	CFLAGS
+#		Change the flags passed to the C compiler. Default = "-O2 -Wall"
+#		For example:
+#			make "CFLAGS = -O3 -Werror"
+#		builds the C code with high optimizations, and C warnings fail.
+#	LDFLAGS
+#		Change the flags passed to the C linker. Empty by default.
+#		For example (on my system with additional dev packages):
+#			make "LDFLAGS = -static"
+#		will build a static fscrypt binary.
+
+# Set the C flags so we don't need to set C flags in each CGO file.
+CFLAGS ?= -O2 -Wall
+
+# Pass the version to the command line program (pulled from tags).
+TAG_VERSION = $(shell git describe --tags 2>/dev/null)
+VERSION = $(if $(TAG_VERSION),$(TAG_VERSION),$(RELEASE_VERSION))
+
+.PHONY: default
 default: $(NAME)
-all: format $(NAME) test
 
-$(NAME): $(OBJECTS)
+sha512.o: sha512.h sha512.c
+	$(CC) $(CFLAGS) sha512.c -c -o $@
+
+$(NAME).o: $(NAME).c sha512.h
+	$(CC) $(CFLAGS) -DVERSION="$(VERSION)" $(NAME).c -c -o $@
+
+$(NAME): $(NAME).o sha512.o
 	$(CC) $(CFLAGS) $(LDFLAGS) $^ -o $@
 
+# Testing fscryptctl (need root permissions)
+.PHONY: root test
+root:
+ifneq ($(shell id -u),0)
+	$(error You must be root to execute this command)
+endif
+
+test: $(NAME) root
+ifeq ("$(wildcard $(MOUNT))","")
+	$(error mountpoint $(MOUNT) does not exist, run "make test-setup")
+endif
+	python -m pytest test.py -s -q
+
+# Format all the Go and C code
+.PHONY: format format-check
 format:
-	@find . -name '*.c' -or -name '*.h' | xargs clang-format -style=Google -i
+	clang-format -i -style=Google $(C_FILES)
 
-test: $(NAME)
-	@python -m pytest test.py -s -q
+format-check:
+	@clang-format -i -style=Google -output-replacements-xml $(C_FILES) \
+	| grep "<replacement " \
+	| ./input_fail.py "Incorrectly formatted C files. Run \"make format\"."
 
+# Installation, uninstallation, and cleanup code
+.PHONY: install uninstall clean
 install: $(NAME)
-	$(INSTALL) -d $(DEST_DIR)
-	$(INSTALL) $(NAME) $(DEST_DIR)
+	$(INSTALL) -d $(DESTDIR)
+	$(INSTALL) $(NAME) $(DESTDIR)
+
+uninstall:
+	rm -f $(DESTDIR)/$(NAME)
 
 clean:
-	rm -f $(OBJECTS)
-	rm -rf $(NAME)
+	rm -f $(NAME) *.o *.pyc $(IMAGE)
 	rm -rf .cache
 	rm -rf __pycache__
+
+##### Setup/Teardown for integration tests (need root permissions) #####
+.PHONY: test-setup test-teardown
+test-setup: root
+	dd if=/dev/zero of=$(IMAGE) bs=1M count=20
+	mkfs.ext4 -b 4096 -O encrypt $(IMAGE) -F
+	mkdir -p $(MOUNT)
+	mount -o rw,loop,user $(IMAGE) $(MOUNT)
+	chmod +777 $(MOUNT)
+
+test-teardown: root
+	umount $(MOUNT)
+	rmdir $(MOUNT)
+	rm -f $(IMAGE)
+
+##### Travis CI Commands
+.PHONY: travis-install travis-script
+travis-install: test-setup
+
+travis-script: format-check default test

--- a/Makefile
+++ b/Makefile
@@ -64,7 +64,7 @@ sha512.o: sha512.h sha512.c
 	$(CC) $(CFLAGS) sha512.c -c -o $@
 
 $(NAME).o: $(NAME).c sha512.h
-	$(CC) $(CFLAGS) -DVERSION="$(VERSION)" $(NAME).c -c -o $@
+	$(CC) $(CFLAGS) -DVERSION="\"$(VERSION)\"" $(NAME).c -c -o $@
 
 $(NAME): $(NAME).o sha512.o
 	$(CC) $(CFLAGS) $(LDFLAGS) $^ -o $@

--- a/fscryptctl.c
+++ b/fscryptctl.c
@@ -132,6 +132,8 @@ static void __attribute__((__noreturn__)) usage(FILE *out) {
       "\nOptions:\n"
       "    -h, --help\n"
       "        print this help screen\n"
+      "    -v, --version\n"
+      "        print the version of fscrypt\n"
       "    insert_key\n"
       "        --ext4\n"
       "            for use with an ext4 filesystem before kernel v4.8\n"
@@ -515,6 +517,10 @@ int main(int argc, char *const argv[]) {
   for (i = 1; i < argc; ++i) {
     if (strcmp(argv[i], "-h") == 0 || strcmp(argv[i], "--help") == 0) {
       usage(stdout);
+    }
+    if (strcmp(argv[i], "-v") == 0 || strcmp(argv[i], "--version") == 0) {
+      puts(VERSION);
+      return EXIT_SUCCESS;
     }
   }
 

--- a/fscryptctl.c
+++ b/fscryptctl.c
@@ -105,7 +105,8 @@ key_serial_t keyctl_get_keyring_ID(key_serial_t id, int create) {
 // Human-readable strings for encryption modes, indexed by the encryption mode
 #define NUM_ENCRYPTION_MODES 7
 const char *const mode_strings[NUM_ENCRYPTION_MODES] = {
-    "INVALID", "AES-256-XTS", "AES-256-GCM", "AES-256-CBC", "AES-256-CTS", "AES-128-CBC", "AES-128-CTS"};
+    "INVALID",     "AES-256-XTS", "AES-256-GCM", "AES-256-CBC",
+    "AES-256-CTS", "AES-128-CBC", "AES-128-CTS"};
 
 // Valid amounts of filename padding, indexed by the padding flag
 #define NUM_PADDING_VALUES 4

--- a/input_fail.py
+++ b/input_fail.py
@@ -1,0 +1,14 @@
+#!/usr/bin/env python
+
+# Exit with 1 if any input is provided. Print the input to stdout, unless an
+# argument is specified. In that case, print the argument instead.
+
+import sys
+
+input_string = sys.stdin.read()
+if input_string != "":
+    if len(sys.argv) >= 2:
+        print(sys.argv[1])
+    else:
+        sys.stdout.write(input_string)
+    sys.exit(1)

--- a/test.py
+++ b/test.py
@@ -19,7 +19,7 @@ import keyutils
 import pytest
 import os
 
-key_length = 64
+key_length = 64 # 512 bit keys
 test_env_var = "TEST_FILESYSTEM_ROOT"
 test_data = "some test file data"
 
@@ -30,12 +30,15 @@ test_data = "some test file data"
 #       | xxd -r -p
 #       | sha512sum --binary
 #       | head --bytes=16
-test_key = b'a' * key_length
-test_descriptor = b'0394a446f8eaa61f'
+
+# The first and second groups of 256 bits must be different.
+half_length = key_length/2
+test_key = (b'a' * half_length) + (b'1' * half_length)
+test_descriptor = b'e355a76a11a1be18'
 key_tests = [
     (test_key, test_descriptor),
-    (b'b' * key_length, b'904a9ca97689ad11'),
-    (b'c' * key_length, b'a8134316f6879ed4'),
+    ((b'b' * half_length) + (b'2' * half_length), b'89bb6950c691e91a'),
+    ((b'c' * half_length) + (b'3' * half_length), b'338561500b313743'),
 ]
 
 
@@ -62,12 +65,20 @@ def invoke(binary_path, stdin, *args):
 
     return first_line(stdout)
 
+def device(mountpoint):
+    """ Returns the device of a mountpoint. """
+    from subprocess import check_output
+    for line in check_output(['mount', '-l']).split('\n'):
+        parts = line.split()
+        if len(parts) > 2 and parts[2] == mountpoint:
+            return parts[0]
+    raise SystemError("No device for: " + mountpoint)
 
 def remount(mountpoint):
-    """ Tries to unmount and mount the filesystem at mountpoint. """
+    """ Remounts the filesystem and clears the inode cache. """
+    dev = device(mountpoint)
     invoke("umount", "", mountpoint)
-    invoke("mount", "", mountpoint)
-
+    invoke("mount", "", "-t", "ext4", dev, mountpoint)
 
 def write_file(path):
     """ writes some sample data to the file at path """


### PR DESCRIPTION
This PR fixes #3 

To do this, the `Makefile`, `input_fail.py`, and `.travis.yml` files from [fscrypt](https://github.com/google/fscrypt) were copied over and modified. In order to get everything working, multiple changes were added.

1. A version flag was added and is now defined in the `Makefile`, similar to how [fscrypt does things](https://github.com/google/fscrypt/blob/d6efd2ab463e82cc3a78860384f26d809bd76ce5/cmd/fscrypt/fscrypt.go#L40-L41).
2. `make test` now works without any prior setup (does not require the testing file to be in `/etc/fstab`).
3. Fixes the testing related key issues that are also fixed in #7 