### PR TITLE
build: respect CPPFLAGS from environment

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -61,10 +61,10 @@ VERSION = $(if $(TAG_VERSION),$(TAG_VERSION),$(RELEASE_VERSION))
 default: $(NAME)
 
 sha512.o: sha512.h sha512.c
-	$(CC) $(CFLAGS) sha512.c -c -o $@
+	$(CC) $(CPPFLAGS) $(CFLAGS) sha512.c -c -o $@
 
 $(NAME).o: $(NAME).c sha512.h
-	$(CC) $(CFLAGS) -DVERSION="\"$(VERSION)\"" $(NAME).c -c -o $@
+	$(CC) $(CPPFLAGS) $(CFLAGS) -DVERSION="\"$(VERSION)\"" $(NAME).c -c -o $@
 
 $(NAME): $(NAME).o sha512.o
 	$(CC) $(CFLAGS) $(LDFLAGS) $^ -o $@


### PR DESCRIPTION
This is important when e.g. wanting to compile with security
flags enabled.

Also GNU make adds CPPFLAGS to the built-in rule to compile
C files, see
  https://www.gnu.org/software/make/manual/html_node/Catalogue-of-Rules.html
This build system should be compatible to that de facto standard.

Signed-off-by: André Draszik <git@andred.net>