### PR TITLE
build: fix mkfs.ext4 invocation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -110,7 +110,7 @@ clean:
 .PHONY: test-setup test-teardown
 test-setup: root
 	dd if=/dev/zero of=$(IMAGE) bs=1M count=20
-	mkfs.ext4 -b 4096 -O encrypt $(IMAGE) -F
+	mkfs.ext4 -b 4096 -O encrypt -F $(IMAGE)
 	mkdir -p $(MOUNT)
 	mount -o rw,loop,user $(IMAGE) $(MOUNT)
 	chmod +777 $(MOUNT)


### PR DESCRIPTION
This currently fails with:
  mkfs.ext4: invalid blocks '-F' on device 'fscryptctl_image'

The reason is that that the argument after the device name
is treated as the file system size.

Move -F in the command line to make it work.

Signed-off-by: André Draszik <git@andred.net>