### PR TITLE
Add hardware-backed crypto support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,6 +28,8 @@ PREFIX ?= /usr/local
 # Directory where the binary gets installed
 BINDIR ?= $(PREFIX)/bin
 
+HW_CRYPTO_SUPPORT ?= 0
+
 # C compiler flags
 CFLAGS ?= -O2 -Wall
 
@@ -36,6 +38,8 @@ CPPFLAGS ?=
 
 # Linker flags
 LDFLAGS ?=
+
+CFLAGS += -DHW_CRYPTO_SUPPORT=$(HW_CRYPTO_SUPPORT)
 
 # Pass the version to the command line program (pulled from tags).
 VERSION ?= $(shell git describe --tags 2>/dev/null)

--- a/fscrypt_uapi.h
+++ b/fscrypt_uapi.h
@@ -125,7 +125,14 @@ struct fscrypt_add_key_arg {
 	struct fscrypt_key_specifier key_spec;
 	__u32 raw_size;
 	__u32 key_id;
+#if HW_CRYPTO_SUPPORT
+	__u32 __reserved[7];
+	/* N.B.: "temporary" flag, not reserved upstream */
+#define __FSCRYPT_ADD_KEY_FLAG_HW_WRAPPED		0x00000001
+	__u32 __flags;
+#else
 	__u32 __reserved[8];
+#endif
 	__u8 raw[];
 };
 


### PR DESCRIPTION
Add build-time support for platforms that support hardware-backed
crypto keys using a non-standard extension found in some Android
kernels.  To enable this, set HW_CRYPTO_SUPPORT prior to building:

 HW_CRYPTO_SUPPORT=1 make

Signed-off-by: Daniel Kristensen <dpk5081@gmail.com>
Change-Id: Idc17d90d0c3aafccf6e6620514e699fe1143f88e