### PR TITLE
fscryptctl: add support for adding key by serial (ID)

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,11 +74,16 @@ tips](https://github.com/google/fscrypt#getting-encryption-not-enabled-on-an-ext
 For full usage details, see the manual page (`man fscryptctl`), or alternatively
 run `fscryptctl --help`.
 
-The `add_key` command accepts the encryption key in binary on standard input.
+The `add_key` command, by default, accepts the encryption key in binary on
+standard input.
 It is critical that this be a real cryptographic key (and not a passphrase, for
 example), since `fscryptctl` doesn't do key stretching itself.  Obviously, don't
 store the raw encryption key alongside the encrypted files.  (If you need
 support for passphrases, use `fscrypt` instead of `fscryptctl`.)
+
+Alternatively, `add_key --serial=$serial` will instruct the kernel to
+extract the kernel material from an existing key of type "fscrypt-provisioning"
+with the specified $serial (The ID returned and used by keyctl(1)).
 
 After running the `add_key` command to add an encryption key to a filesystem,
 you can use the `set_policy` command to create an encrypted directory on that

--- a/fscryptctl.1.md
+++ b/fscryptctl.1.md
@@ -40,7 +40,7 @@ feature, see the references at the end of this page.
 
 # SUBCOMMANDS
 
-## **fscryptctl add_key** *MOUNTPOINT*
+## **fscryptctl add_key** [*OPTION*..] *MOUNTPOINT*
 
 Add an encryption key to the given mounted filesystem.  This will "unlock" any
 files and directories that are protected by the given key on the given
@@ -54,7 +54,13 @@ If successful, **fscryptctl add_key** will print the key identifier of the newly
 added key; this will be a 32-character hex string which can be passed to other
 **fscryptctl** commands.
 
-**fscryptctl add_key** does not accept any options.
+Options accepted by **fscryptctl add_key**:
+
+**\-\-serial**=*SERIAL*
+:   Don't read raw key material from standard input. Instead, instruct the
+    kernel to extract key material from an existing key of type
+    `fscrypt-provisioning` with specified SERIAL. SERIAL is the ID returned
+    and used by keyctl(1).
 
 ## **fscryptctl remove_key** [*OPTION*...] *KEY_IDENTIFIER* *MOUNTPOINT*
 


### PR DESCRIPTION
Since Linux commit https://github.com/torvalds/linux/commit/93edd392ca ("fscrypt: support passing a keyring key
to FS_IOC_ADD_ENCRYPTION_KEY"), it's possible to pass the key ID of
a "fscrypt-provisioning" key that Linux should retrieve the raw key
material from instead of passing it directly from userspace.

This is useful to add fscrypt keys after unmounting and re-mounting.
It would also prove useful should additional key types like trusted keys
be allowed in future.

Thus add a new `--serial` parameter to `add_key` to facilitate this.
`--serial` was chosen over `--id` to avoid confusion with the `KEY_IDENTIFIER`
used in the `remove_key`, `key_status` and `set_policy` documentation, which
it is not interchangeable with.

---

This is PR is applicable regardless of my patch for [adding fscrypt support for
trusted keys](https://lore.kernel.org/linux-fscrypt/20210727144349.11215-1-a.fatoum@pengutronix.de/T/#u).

Should a revised version of that patch be applied, I'll create a new pull request to adjust the documentation here appropriately. There is no code change necessary however, because the API used for fscrypt-provisioning keys is reused.