### PR TITLE
Remove test for AES-256-XTS with 32-byte master key

### DIFF
--- a/test.py
+++ b/test.py
@@ -313,8 +313,9 @@ def test_set_get_policy_aes_256_xts(directory):
     prepare_encrypted_dir(directory, "--contents=AES-256-XTS",
                           "--filenames=AES-256-CTS")
     check_policy(directory, contents="AES-256-XTS", filenames="AES-256-CTS")
-    # AES-256-XTS expects a 64-byte key.  Shorter keys shouldn't work.
-    for key in [TEST_KEY_16B, TEST_KEY_32B]:
+    # AES-256-XTS is only allowed with master keys that are 32 bytes or longer.
+    # Shorter keys shouldn't work.
+    for key in [TEST_KEY_16B]:
         with pytest.raises(OSError):
             prepare_encrypted_dir(directory, "--contents=AES-256-XTS",
                                   "--filenames=AES-256-CTS", key=key)


### PR DESCRIPTION
The v5.16 kernel intentionally reduced the minimum master key size for
AES-256-XTS from 64 bytes to 32 bytes, provided that a v2 encryption
policy is used.  See https://git.kernel.org/linus/7f595d6a6cdc3368

Therefore, remove the fscryptctl test which verified that 32-byte master
keys were not allowed with AES-256-XTS.

Fixes #26