### PR TITLE
Add support for AES-256-HCTR2 filenames encryption

### DIFF
--- a/fscrypt_uapi.h
+++ b/fscrypt_uapi.h
@@ -20,7 +20,6 @@
 #define FSCRYPT_POLICY_FLAG_DIRECT_KEY		0x04
 #define FSCRYPT_POLICY_FLAG_IV_INO_LBLK_64	0x08
 #define FSCRYPT_POLICY_FLAG_IV_INO_LBLK_32	0x10
-#define FSCRYPT_POLICY_FLAGS_VALID		0x1F
 
 /* Encryption algorithms */
 #define FSCRYPT_MODE_AES_256_XTS		1
@@ -28,7 +27,8 @@
 #define FSCRYPT_MODE_AES_128_CBC		5
 #define FSCRYPT_MODE_AES_128_CTS		6
 #define FSCRYPT_MODE_ADIANTUM			9
-#define __FSCRYPT_MODE_MAX			9
+#define FSCRYPT_MODE_AES_256_HCTR2		10
+/* If adding a mode number > 10, update FSCRYPT_MODE_MAX in fscrypt_private.h */
 
 /*
  * Legacy policy version; ad-hoc KDF and no key verification.
@@ -177,7 +177,7 @@ struct fscrypt_get_key_status_arg {
 #define FS_POLICY_FLAGS_PAD_32		FSCRYPT_POLICY_FLAGS_PAD_32
 #define FS_POLICY_FLAGS_PAD_MASK	FSCRYPT_POLICY_FLAGS_PAD_MASK
 #define FS_POLICY_FLAG_DIRECT_KEY	FSCRYPT_POLICY_FLAG_DIRECT_KEY
-#define FS_POLICY_FLAGS_VALID		FSCRYPT_POLICY_FLAGS_VALID
+#define FS_POLICY_FLAGS_VALID		0x07	/* contains old flags only */
 #define FS_ENCRYPTION_MODE_INVALID	0	/* never used */
 #define FS_ENCRYPTION_MODE_AES_256_XTS	FSCRYPT_MODE_AES_256_XTS
 #define FS_ENCRYPTION_MODE_AES_256_GCM	2	/* never used */

--- a/fscryptctl.1.md
+++ b/fscryptctl.1.md
@@ -119,7 +119,8 @@ Options accepted by **fscryptctl set_policy**:
 
 **\-\-filenames**=*MODE*
 :   The cipher that will be used to encrypt filenames.  Valid options are
-    AES-256-CTS, AES-128-CTS, and Adiantum.  Default is AES-256-CTS.
+    AES-256-CTS, AES-128-CTS, Adiantum, and AES-256-HCTR2.  Default is
+    AES-256-CTS.
 
 **\-\-padding**=*BYTES*
 :   The number of bytes to which encrypted filename lengths will be aligned

--- a/fscryptctl.c
+++ b/fscryptctl.c
@@ -72,6 +72,7 @@ static const char *const mode_strings[] = {
     [FSCRYPT_MODE_AES_128_CBC] = "AES-128-CBC",
     [FSCRYPT_MODE_AES_128_CTS] = "AES-128-CTS",
     [FSCRYPT_MODE_ADIANTUM] = "Adiantum",
+    [FSCRYPT_MODE_AES_256_HCTR2] = "AES-256-HCTR2",
 };
 
 // Valid amounts of filename padding, indexed by the padding flag


### PR DESCRIPTION
This was added in Linux v6.0-rc1.