### PR TITLE
Revert "ci.yml: work around ASAN binaries crashing on ubuntu-latest"

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -91,8 +91,6 @@ jobs:
       run: |
         sudo apt-get update
         sudo apt-get install -y clang $ALL_DEPENDENCIES
-    - name: Work around https://github.com/actions/runner-images/issues/9491
-      run: sudo sysctl vm.mmap_rnd_bits=28
     - name: Build and test
       run: make test-all CC=clang CFLAGS="$CFLAGS -fsanitize=address -fno-sanitize-recover=address"
 


### PR DESCRIPTION
This reverts commit 0ee1ea425add3748ac7bb94340627d0e6d08cb29 since it is no longer needed.